### PR TITLE
Add `from_dbc_file` fn for creating `PgnLibrary`

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,23 +25,12 @@ implemented as folows:
 ```rust
 extern crate canparse;
 
-use canparse::{PgnLibrary, SpnDefinition, Entry, ParseMessage};
-use std::str::FromStr;
-use std::collections::HashMap;
-use std::io::BufRead;
+use canparse::{PgnLibrary, SpnDefinition, ParseMessage};
 
 fn main() {
-    let mut lib = PgnLibrary::new( HashMap::default() );
 
-    let br = include_bytes!("./j1939.dbc");
-
-    // Parse db lines into PgnLibrary
-    for l in br.lines() {
-        let line = l.unwrap();
-        if let Some(entry) = Entry::from_str(line.as_str()).ok() {
-            lib.add_entry(entry).ok();
-        }
-    }
+    // Parse dbc file into PgnLibrary
+    fn lib = PgnLibrary::from_dbc_file("./j1939.dbc").unwrap();
 
     // Pull signal definition for engine speed
     let enginespeed_def: &SpnDefinition = lib

--- a/src/dbc.rs
+++ b/src/dbc.rs
@@ -290,7 +290,7 @@ impl FromStr for Entry {
                 },
                 None => panic!("Parsing failed")
             }.unwrap()
-        }).ok_or("Pattern match failed".to_string())
+        }).ok_or_else(|| "Pattern match failed".to_string())
     }
 }
 

--- a/tests/pgnlibrary.rs
+++ b/tests/pgnlibrary.rs
@@ -15,7 +15,7 @@ fn pgnlib_build_parse() {
     // Parse db lines into PgnLibrary
     for l in br.lines() {
         let line = l.unwrap();
-        if let Some(entry) = Entry::from_str(line.as_str()).ok() {
+        if let Ok(entry) = Entry::from_str(line.as_str()) {
             lib.add_entry(entry).ok();
         }
     }
@@ -28,6 +28,15 @@ fn pgnlib_build_parse() {
     let msg: [u8; 8] = [0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88];
     let engine_speed: f32 = enginespeed_def.parse_message(&msg).unwrap();
 
-    assert_eq!(engine_speed, 2728.5);
+    assert!(engine_speed - 2728.5 < std::f32::EPSILON);
 }
 
+#[test]
+fn pgnlib_from_dbc_file() {
+
+    let lib = PgnLibrary::from_dbc_file("./tests/data/sample.dbc");
+    assert!(lib.is_ok(), "PgnLibrary should have built successfully.");
+
+    let lib_fail = PgnLibrary::from_dbc_file("./tests/data/sample.dbc.fail");
+    assert_eq!(lib_fail.map_err(|e| e.kind()), Err(std::io::ErrorKind::NotFound))
+}


### PR DESCRIPTION
This function avoids the boilerplate required to assemble a `PgnLibrary`
from a DBC file, ignoring extraneous `Entry` variants while returning an
error only on io failures.  `add_entry` is still available for other
sources, such as stdin.