### PR TITLE
Explicitly parse file using ISO-8859-1 codec

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](http://semver.org).
 - Change `get_spn` to take `&str` input
 - Speed up parsing PGN from `&[u8]`
 
+### Fixed
+- Explicitly parse file passed into `PgnLibrary::from_dbc_file` using
+  ISO-8859-1 codec
+
 ## [0.1.2] - 2018-06-09
 
 ### Changed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ use-socketcan = ["socketcan"]
 rustc-serialize = "0.3.24"
 regex = "0.2.2"
 lazy_static = "0.2.8"
+encoding = "0.2"
 enum_primitive = "0.1.1"
 num = "0.1.37"
 byteorder = "1.0.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -43,6 +43,7 @@
 
 #![crate_name = "canparse"]
 
+extern crate encoding;
 #[macro_use] extern crate enum_primitive;
 #[macro_use] extern crate lazy_static;
 extern crate num;

--- a/tests/data/sample.dbc
+++ b/tests/data/sample.dbc
@@ -1,4 +1,4 @@
-VERSION "A version string"
+VERSION "A version string°"
 
 BO_ 2364539904 EEC1 : 8 Vector__XXX
 CM_ BO_ 2364539904 "Engine Controller";

--- a/tests/pgnlibrary.rs
+++ b/tests/pgnlibrary.rs
@@ -5,18 +5,17 @@ use canparse::dbc::Entry;
 use canparse::pgn::{PgnLibrary, SpnDefinition, ParseMessage};
 use std::str::FromStr;
 use std::collections::HashMap;
-use std::io::BufRead;
 
 #[test]
 fn pgnlib_build_parse() {
     let mut lib = PgnLibrary::new( HashMap::default() );
 
-    let br = include_bytes!("./data/sample.dbc");
+    let data: String = include_bytes!("./data/sample.dbc")
+        .iter().map(|b| *b as char).collect();
 
     // Parse db lines into PgnLibrary
-    for l in br.lines() {
-        let line = l.unwrap();
-        if let Ok(entry) = Entry::from_str(line.as_str()) {
+    for line in data.lines() {
+        if let Ok(entry) = Entry::from_str(&line) {
             lib.add_entry(entry).ok();
         }
     }


### PR DESCRIPTION
Introduces the `encoding` crate to parse a given DBC file assuming
ISO-8859-1 (Latin-1) when using `PgnLibrary::from_dbc_file`.

Also makes available `PgnLibrary::from_encoded_dbc_file` that can be
used to parse DBC files other than ISO-8859-1, via the `Encoding` trait
provided by `encoding`.

Fixes #8.