### PR TITLE
Update and clean out old deps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org).
 
 ## [Unreleased]
 
+### Changed
+- Update and clean out old deps
+
 ## [0.1.3] - 2018-02-09
 
 ### Changed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,18 +18,16 @@ default = []
 use-socketcan = ["socketcan"]
 
 [dependencies]
-rustc-serialize = "0.3.24"
-regex = "0.2.2"
-lazy_static = "0.2.8"
+rustc-serialize = "0.3"
+regex = "1.1"
+lazy_static = "1.2"
 encoding = "0.2"
-enum_primitive = "0.1.1"
-num = "0.1.37"
-byteorder = "1.0.0"
-socketcan = { version = "1.6.0", optional = true }
+enum_primitive = "0.1"
+byteorder = "1.3"
+socketcan = { version = "1.7", optional = true }
 
 [dev-dependencies]
-time = "0.1.37"
-rand = "0.3"
+rand = "0.6"
 
 [package.metadata.docs.rs]
 features = ["use-socketcan"]

--- a/src/dbc.rs
+++ b/src/dbc.rs
@@ -2,7 +2,7 @@
 
 #![allow(non_upper_case_globals)]
 
-use num::FromPrimitive;
+use enum_primitive::FromPrimitive;
 use std::str::FromStr;
 use rustc_serialize::{Decodable, Decoder};
 use regex::{Regex, RegexSet};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -46,7 +46,6 @@
 extern crate encoding;
 #[macro_use] extern crate enum_primitive;
 #[macro_use] extern crate lazy_static;
-extern crate num;
 extern crate regex;
 extern crate rustc_serialize;
 extern crate byteorder;


### PR DESCRIPTION
Relaxes the semver requirements to the minor for all dependencies, since
there are no obvious breakages with the current list of crates.