### PR TITLE
Replace regex DBC parser with nom

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org).
 
 ### Changed
 - Update and clean out old deps
+- Replace regex parsing with `nom` to handle strings with newlines
 
 ## [0.1.3] - 2018-02-09
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,7 @@ encoding = "0.2"
 enum_primitive = "0.1"
 byteorder = "1.3"
 socketcan = { version = "1.7", optional = true }
+nom = "4.2"
 
 [dev-dependencies]
 rand = "0.6"

--- a/src/dbc.rs
+++ b/src/dbc.rs
@@ -3,13 +3,13 @@
 #![allow(non_upper_case_globals)]
 
 use enum_primitive::FromPrimitive;
-use std::str::FromStr;
-use rustc_serialize::{Decodable, Decoder};
 use regex::{Regex, RegexSet};
-use std::fmt::{Display, Formatter};
-use std::fmt;
-use std::error::Error;
+use rustc_serialize::{Decodable, Decoder};
 use std;
+use std::error::Error;
+use std::fmt;
+use std::fmt::{Display, Formatter};
+use std::str::FromStr;
 
 #[derive(Debug, PartialEq, Clone)]
 pub struct Version(pub String);
@@ -22,14 +22,14 @@ pub struct MessageDefinition {
     pub id: String,
     pub name: String,
     pub message_len: u32,
-    pub sending_node: String
+    pub sending_node: String,
 }
 
 #[derive(Debug, PartialEq, Clone)]
 pub struct MessageDescription {
     pub id: String,
     pub signal_name: String,
-    pub description: String
+    pub description: String,
 }
 
 #[derive(Debug, PartialEq, Clone)]
@@ -37,7 +37,7 @@ pub struct MessageAttribute {
     pub name: String,
     pub id: String,
     pub signal_name: String,
-    pub value: String
+    pub value: String,
 }
 
 #[derive(Debug, PartialEq, Clone)]
@@ -52,14 +52,14 @@ pub struct SignalDefinition {
     pub min_value: f32,
     pub max_value: f32,
     pub units: String,
-    pub receiving_node: String
+    pub receiving_node: String,
 }
 
 #[derive(Debug, PartialEq, Clone)]
 pub struct SignalDescription {
     pub id: String,
     pub signal_name: String,
-    pub description: String
+    pub description: String,
 }
 
 #[derive(Debug, PartialEq, Clone)]
@@ -67,13 +67,12 @@ pub struct SignalAttribute {
     pub name: String,
     pub id: String,
     pub signal_name: String,
-    pub value: String
+    pub value: String,
 }
 
 /// Composed DBC entry.
 #[derive(Debug, PartialEq, Clone)]
 pub enum Entry {
-
     /// `VERSION`
     Version(Version),
 
@@ -85,7 +84,6 @@ pub enum Entry {
     // `CM_ BU_ [can id] [signal name] "[description]"`
     // CanNodesDescription,
     // CanNodesAttribute,
-
     /// `BO_ [can id] [message name]: [message length] [sending node]`
     MessageDefinition(MessageDefinition),
     /// `CM_ BO_ [can id] [signal name] "[description]"`
@@ -111,7 +109,6 @@ pub enum Entry {
 
     // `BA_ "[attribute name]" [BU_|BO_|SG_] [node|can id] [signal name] [attribute value];`
     // Attribute
-
     Unknown(String),
 }
 
@@ -469,8 +466,10 @@ impl EntryErrorKind {
     pub fn __description(&self) -> &str {
         match *self {
             EntryErrorKind::RegexNoMatch => "could not find a regex match for input",
-            EntryErrorKind::UnknownEntryType(_) => "integer could not be converted into valid EntryType",
-            EntryErrorKind::RegexCapture => "failure to combine all values from regex capture"
+            EntryErrorKind::UnknownEntryType(_) => {
+                "integer could not be converted into valid EntryType"
+            }
+            EntryErrorKind::RegexCapture => "failure to combine all values from regex capture",
         }
     }
     #[doc(hidden)]
@@ -492,9 +491,7 @@ impl Display for EntryErrorKind {
 
 impl From<EntryErrorKind> for ParseEntryError {
     fn from(kind: EntryErrorKind) -> Self {
-        ParseEntryError {
-            kind
-        }
+        ParseEntryError { kind }
     }
 }
 
@@ -513,7 +510,7 @@ mod tests {
     use std::str::FromStr;
 
     macro_rules! test_entry {
-        ($test_name: ident, $entry_type: ident, $test_line: expr, $expected: expr) => (
+        ($test_name: ident, $entry_type: ident, $test_line: expr, $expected: expr) => {
             mod $test_name {
                 use dbc::*;
                 use std::str::FromStr;
@@ -522,7 +519,7 @@ mod tests {
                 fn from_str() {
                     assert_eq!(
                         Entry::from_str($test_line),
-                        Ok(Entry::$entry_type ( $expected ))
+                        Ok(Entry::$entry_type($expected))
                     );
                 }
 
@@ -542,37 +539,35 @@ mod tests {
 
                 #[test]
                 fn entry_type() {
-                    let entry = Entry::$entry_type( $expected );
+                    let entry = Entry::$entry_type($expected);
                     let entry_type = EntryType::$entry_type;
 
                     assert_eq!(entry.get_type(), entry_type);
-                    assert_eq!(
-                        format!("{}", entry),
-                        format!("{}", entry_type),
-                    );
+                    assert_eq!(format!("{}", entry), format!("{}", entry_type),);
                 }
 
                 #[test]
                 fn nom_parse() {
-                    assert_eq!(
-                        nom::$test_name($test_line).unwrap().1,
-                        $expected
-                    );
+                    assert_eq!(nom::$test_name($test_line).unwrap().1, $expected);
                     assert_eq!(
                         nom::entry($test_line).unwrap().1,
-                        Entry::$entry_type( $expected )
+                        Entry::$entry_type($expected)
                     );
                 }
             }
-        )
+        };
     }
 
-    test_entry!( version, Version,
+    test_entry!(
+        version,
+        Version,
         "VERSION \"A version string\"\n",
-        Version ( "A version string".to_string() )
+        Version("A version string".to_string())
     );
 
-    test_entry!( message_definition, MessageDefinition,
+    test_entry!(
+        message_definition,
+        MessageDefinition,
         "BO_ 2364539904 EEC1 : 8 Vector__XXX\n",
         MessageDefinition {
             id: "2364539904".to_string(),
@@ -582,12 +577,20 @@ mod tests {
         }
     );
 
-    test_entry!( message_description, MessageDescription,
+    test_entry!(
+        message_description,
+        MessageDescription,
         "CM_ BO_ 2364539904 \"Engine Controller\";\n",
-        MessageDescription { id: "2364539904".to_string(), signal_name: "".to_string(), description: "Engine Controller".to_string()}
+        MessageDescription {
+            id: "2364539904".to_string(),
+            signal_name: "".to_string(),
+            description: "Engine Controller".to_string()
+        }
     );
 
-    test_entry!( message_attribute, MessageAttribute,
+    test_entry!(
+        message_attribute,
+        MessageAttribute,
         "BA_ \"SingleFrame\" BO_ 2364539904 0;\n",
         MessageAttribute {
             name: "SingleFrame".to_string(),
@@ -597,7 +600,9 @@ mod tests {
         }
     );
 
-    test_entry!( signal_definition, SignalDefinition,
+    test_entry!(
+        signal_definition,
+        SignalDefinition,
         " SG_ Engine_Speed : 24|16@1+ (0.125,0) [0|8031.88] \"rpm\" Vector__XXX\n",
         SignalDefinition {
             name: "Engine_Speed".to_string(),
@@ -614,7 +619,9 @@ mod tests {
         }
     );
 
-    test_entry!( signal_description, SignalDescription,
+    test_entry!(
+        signal_description,
+        SignalDescription,
         "CM_ SG_ 2364539904 Engine_Speed \"A description for Engine speed.\";\n",
         SignalDescription {
             id: "2364539904".to_string(),
@@ -623,7 +630,9 @@ mod tests {
         }
     );
 
-    test_entry!( signal_attribute, SignalAttribute,
+    test_entry!(
+        signal_attribute,
+        SignalAttribute,
         "BA_ \"SPN\" SG_ 2364539904 Engine_Speed 190;\n",
         SignalAttribute {
             name: "SPN".to_string(),
@@ -634,16 +643,19 @@ mod tests {
     );
 
     mod multiline {
-        test_entry!( signal_description, SignalDescription,
+        test_entry!(
+            signal_description,
+            SignalDescription,
             "CM_ SG_ 2364539904 Actual_Engine___Percent_Torque_High_Resolution \"A multi- \r \
-            \r \
-            line description for Engine torque.\";\n",
+             \r \
+             line description for Engine torque.\";\n",
             SignalDescription {
                 id: "2364539904".to_string(),
                 signal_name: "Actual_Engine___Percent_Torque_High_Resolution".to_string(),
                 description: "A multi- \r \
-                \r \
-                line description for Engine torque.".to_string()
+                              \r \
+                              line description for Engine torque."
+                    .to_string()
             }
         );
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -49,6 +49,7 @@ extern crate encoding;
 extern crate regex;
 extern crate rustc_serialize;
 extern crate byteorder;
+#[macro_use] extern crate nom;
 
 #[cfg(feature = "use-socketcan")]
 extern crate socketcan;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -35,21 +35,22 @@
 //! ```
 
 #![cfg_attr(feature = "cargo-clippy", allow(redundant_field_names))]
-
 #![allow(non_snake_case, non_camel_case_types)]
 #![allow(unused_variables, dead_code)]
 #![allow(unused_imports, unused_mut)]
 #![allow(plugin_as_library)]
-
 #![crate_name = "canparse"]
 
 extern crate encoding;
-#[macro_use] extern crate enum_primitive;
-#[macro_use] extern crate lazy_static;
+#[macro_use]
+extern crate enum_primitive;
+#[macro_use]
+extern crate lazy_static;
+extern crate byteorder;
 extern crate regex;
 extern crate rustc_serialize;
-extern crate byteorder;
-#[macro_use] extern crate nom;
+#[macro_use]
+extern crate nom;
 
 #[cfg(feature = "use-socketcan")]
 extern crate socketcan;

--- a/src/pgn.rs
+++ b/src/pgn.rs
@@ -375,6 +375,10 @@ impl FromDbc for PgnDefinition {
                 Ok(())
             },
             Entry::SignalAttribute ( wrapped ) => {
+                if wrapped.name != "SPN" {
+                    // Skip non-SPN attributes
+                    return Ok(());
+                }
                 if self.spns.contains_key(&wrapped.signal_name) {
                     (*self.spns.get_mut(&wrapped.signal_name).unwrap())
                         .merge_entry(Entry::SignalAttribute(wrapped)).unwrap();

--- a/tests/pgnlibrary.rs
+++ b/tests/pgnlibrary.rs
@@ -1,14 +1,13 @@
 extern crate canparse;
 
-use canparse::pgn::{PgnLibrary, SpnDefinition, ParseMessage};
+use canparse::pgn::{ParseMessage, PgnLibrary, SpnDefinition};
 
 #[test]
 fn pgnlib_build_parse() {
     let lib = PgnLibrary::from_dbc_file("./tests/data/sample.dbc").unwrap();
 
     // Pull signal definition for engine speed
-    let enginespeed_def: &SpnDefinition = lib
-        .get_spn("Engine_Speed").unwrap();
+    let enginespeed_def: &SpnDefinition = lib.get_spn("Engine_Speed").unwrap();
 
     // Parse frame containing engine speed
     let msg: [u8; 8] = [0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88];
@@ -19,10 +18,12 @@ fn pgnlib_build_parse() {
 
 #[test]
 fn pgnlib_from_dbc_file() {
-
     let lib = PgnLibrary::from_dbc_file("./tests/data/sample.dbc");
     assert!(lib.is_ok(), "PgnLibrary should have built successfully.");
 
     let lib_fail = PgnLibrary::from_dbc_file("./tests/data/sample.dbc.fail");
-    assert_eq!(lib_fail.map_err(|e| e.kind()), Err(std::io::ErrorKind::NotFound))
+    assert_eq!(
+        lib_fail.map_err(|e| e.kind()),
+        Err(std::io::ErrorKind::NotFound)
+    )
 }

--- a/tests/pgnlibrary.rs
+++ b/tests/pgnlibrary.rs
@@ -1,24 +1,10 @@
-
 extern crate canparse;
 
-use canparse::dbc::Entry;
 use canparse::pgn::{PgnLibrary, SpnDefinition, ParseMessage};
-use std::str::FromStr;
-use std::collections::HashMap;
 
 #[test]
 fn pgnlib_build_parse() {
-    let mut lib = PgnLibrary::new( HashMap::default() );
-
-    let data: String = include_bytes!("./data/sample.dbc")
-        .iter().map(|b| *b as char).collect();
-
-    // Parse db lines into PgnLibrary
-    for line in data.lines() {
-        if let Ok(entry) = Entry::from_str(&line) {
-            lib.add_entry(entry).ok();
-        }
-    }
+    let lib = PgnLibrary::from_dbc_file("./tests/data/sample.dbc").unwrap();
 
     // Pull signal definition for engine speed
     let enginespeed_def: &SpnDefinition = lib


### PR DESCRIPTION
Replaces the `String::lines`, `FromStr`-based parser with nom. This
allows for correct handling of entries containing quoted strings that
may themselves contain newline characters. All regex code is removed,
aside from some leftover Error types that will soon get removed as well.

Fixes #12.