### PR TITLE
Fixed panic literal warning

### DIFF
--- a/src/dbc/library.rs
+++ b/src/dbc/library.rs
@@ -432,6 +432,6 @@ mod tests {
         let unsupported = Entry::Version(Version("Don't care about version entry".to_string()));
         let res = dbclib.add_entry(unsupported);
 
-        assert!(res.is_err(), "Unsupported entry: Version".to_string());
+        assert!(res.is_err(), "Unsupported entry: Version");
     }
 }

--- a/src/pgn.rs
+++ b/src/pgn.rs
@@ -876,7 +876,7 @@ mod tests {
         let unsupported = Entry::Version(Version("Don't care about version entry".to_string()));
         let res = pgnlib.add_entry(unsupported);
 
-        assert!(res.is_err(), "Unsupported entry: Version".to_string());
+        assert!(res.is_err(), "Unsupported entry: Version");
     }
 
     #[test]


### PR DESCRIPTION
This crate has warnings in the latest version of Rust thanks to [this new warning](https://doc.rust-lang.org/nightly/edition-guide/rust-2021/panic-macro-consistency.html). This PR fixes it