### PR TITLE
Fix message names

### DIFF
--- a/src/dbc/library.rs
+++ b/src/dbc/library.rs
@@ -315,7 +315,7 @@ impl DbcLibrary {
         while !i.is_empty() {
             match parser::entry(i) {
                 Ok((new_i, entry)) => {
-                    println!("String just parsed: {}", &i[0..(i.len() - new_i.len())]);
+                    println!("String just parsed: {:?}", &i[0..(i.len() - new_i.len())]);
                     if let Err(_e) = lib.add_entry(entry) {
                         // TODO: Handle add_entry error
                     }
@@ -326,7 +326,7 @@ impl DbcLibrary {
                     break;
                 }
                 Err(_) => {
-                    println!("Failed to parse string starting in: {}", &i[0..1]);
+                    println!("Failed to parse string starting in: {:?}", &i[0..1]);
                     i = &i[1..];
                 }
             }

--- a/src/dbc/library.rs
+++ b/src/dbc/library.rs
@@ -315,7 +315,6 @@ impl DbcLibrary {
         while !i.is_empty() {
             match parser::entry(i) {
                 Ok((new_i, entry)) => {
-                    println!("String just parsed: {:?}", &i[0..(i.len() - new_i.len())]);
                     if let Err(_e) = lib.add_entry(entry) {
                         // TODO: Handle add_entry error
                     }
@@ -326,7 +325,6 @@ impl DbcLibrary {
                     break;
                 }
                 Err(_) => {
-                    println!("Failed to parse string starting in: {:?}", &i[0..1]);
                     i = &i[1..];
                 }
             }
@@ -338,8 +336,6 @@ impl DbcLibrary {
 
 impl DbcLibrary {
     pub fn add_entry(&mut self, entry: Entry) -> Result<(), String> {
-        println!("Parsed entry: {:?}", entry);
-
         let _id: u32 = *match entry {
             Entry::MessageDefinition(dbc::MessageDefinition { ref id, .. }) => id,
             Entry::MessageDescription(dbc::MessageDescription { ref id, .. }) => id,
@@ -358,8 +354,6 @@ impl DbcLibrary {
                 return Err(format!("Unsupported entry: {}.", entry));
             }
         };
-
-        println!("Using ID: {}", _id);
 
         self.messages
             .entry(_id)

--- a/src/dbc/library.rs
+++ b/src/dbc/library.rs
@@ -359,6 +359,8 @@ impl DbcLibrary {
             }
         };
 
+        println!("Using ID: {}", _id);
+
         self.messages
             .entry(_id)
             .and_modify(|cur_entry| {

--- a/src/dbc/library.rs
+++ b/src/dbc/library.rs
@@ -315,6 +315,7 @@ impl DbcLibrary {
         while !i.is_empty() {
             match parser::entry(i) {
                 Ok((new_i, entry)) => {
+                    println!("String just parsed: {}", &i[0..(i.len() - new_i.len())]);
                     if let Err(_e) = lib.add_entry(entry) {
                         // TODO: Handle add_entry error
                     }
@@ -325,6 +326,7 @@ impl DbcLibrary {
                     break;
                 }
                 Err(_) => {
+                    println!("Failed to parse string starting in: {}", &i[0..1]);
                     i = &i[1..];
                 }
             }
@@ -336,6 +338,8 @@ impl DbcLibrary {
 
 impl DbcLibrary {
     pub fn add_entry(&mut self, entry: Entry) -> Result<(), String> {
+        println!("Parsed entry: {:?}", entry);
+
         let _id: u32 = *match entry {
             Entry::MessageDefinition(dbc::MessageDefinition { ref id, .. }) => id,
             Entry::MessageDescription(dbc::MessageDescription { ref id, .. }) => id,
@@ -354,8 +358,6 @@ impl DbcLibrary {
                 return Err(format!("Unsupported entry: {}.", entry));
             }
         };
-
-        println!("Parsing entry: {:?}", entry);
 
         self.messages
             .entry(_id)

--- a/src/dbc/library.rs
+++ b/src/dbc/library.rs
@@ -355,6 +355,8 @@ impl DbcLibrary {
             }
         };
 
+        println!("Parsing entry: {:?}", entry);
+
         self.messages
             .entry(_id)
             .and_modify(|cur_entry| {

--- a/src/dbc/parser.rs
+++ b/src/dbc/parser.rs
@@ -69,6 +69,7 @@ named!(pub bus_configuration<&str, BusConfiguration>,
 named!(pub message_definition<&str, MessageDefinition>,
     do_parse!(
         tag!("BO_")   >>
+        space >>
         text: take_until_either!("\t\r\n") >>
         line_ending >>
         ( MessageDefinition {

--- a/src/dbc/parser.rs
+++ b/src/dbc/parser.rs
@@ -70,10 +70,13 @@ named!(pub message_definition<&str, MessageDefinition>,
     do_parse!(
         tag!("BO_")   >>
         space >>
+        id: map_res!(
+            digit,
+            FromStr::from_str) >>
         text: take_until_either!("\t\r\n") >>
         line_ending >>
         ( MessageDefinition {
-            id: 0,
+            id,
             name: "whatever".into(),
             message_len: 8,
             sending_node: "lol".into(),

--- a/src/dbc/parser.rs
+++ b/src/dbc/parser.rs
@@ -83,7 +83,6 @@ named!(pub message_definition<&str, MessageDefinition>,
             FromStr::from_str) >>
         space >>
         sending_node: take_until_either!(" \t\r\n") >>
-        space0 >>
         line_ending >>
         ( MessageDefinition {
             id: id,

--- a/src/dbc/parser.rs
+++ b/src/dbc/parser.rs
@@ -73,6 +73,7 @@ named!(pub message_definition<&str, MessageDefinition>,
         id: map_res!(
             digit,
             FromStr::from_str) >>
+        space >>
         text: take_until_either!("\t\r\n") >>
         line_ending >>
         ( MessageDefinition {

--- a/src/dbc/parser.rs
+++ b/src/dbc/parser.rs
@@ -69,26 +69,13 @@ named!(pub bus_configuration<&str, BusConfiguration>,
 named!(pub message_definition<&str, MessageDefinition>,
     do_parse!(
         tag!("BO_")   >>
-        space >>
-        id: map_res!(
-            digit,
-            FromStr::from_str) >>
-        space >>
-        name: alphanumeric >>
-        space0 >>
-        tag!(":")   >>
-        space >>
-        len: map_res!(
-            digit,
-            FromStr::from_str) >>
-        space >>
-        sending_node: take_until_either!(" \t\r\n") >>
+        text: take_until_either!("\t\r\n") >>
         line_ending >>
         ( MessageDefinition {
-            id: id,
-            name: name.to_string(),
-            message_len: len,
-            sending_node: sending_node.to_string(),
+            id: 0,
+            name: "whatever".into(),
+            message_len: 8,
+            sending_node: "lol".into(),
         } )
     )
 );


### PR DESCRIPTION
CAN message names can contain underscores. As such, some dbc files can't be accurately parsed using this library. This PR fixes that